### PR TITLE
Updated maximum client body size

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -5,6 +5,7 @@ events {
 }
 
 http {
+    client_max_body_size 1024M;
     server {
         listen _XNGINX_PORT default_server;
 


### PR DESCRIPTION
Updated the maximum client body size configuration value to solve a 413 Request Entity Too Large Error in Nginx when uploading a plugin > 1MB.