### PR TITLE
bump nginx to 1.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.9.9
+FROM nginx:1.10.1
 WORKDIR /tmp
 
 # Environment variables used throughout this Dockerfile

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ up and running quickly with Jenkins on DC/OS.
 ## Included in this repo
 Base packages:
   * [Jenkins][jenkins-home] 2.7.2 (LTS)
-  * [Nginx][nginx-home] 1.9.9
+  * [Nginx][nginx-home] 1.10.1
 
 Jenkins plugins:
   * ace-editor v1.1


### PR DESCRIPTION
This commit bumps Nginx from 1.9.9 to 1.10.1, the current stable
version.