### PR TITLE
Add Jenkins Options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ java ${JVM_OPTS}                                    \
     -Dhudson.DNSMultiCast.disabled=true             \
     -Djenkins.install.runSetupWizard=false          \
     -jar ${JENKINS_FOLDER}/jenkins.war              \
+    ${JENKINS_OPTS}                                 \
     --httpPort=${PORT1}                             \
     --webroot=${JENKINS_FOLDER}/war                 \
     --ajp13Port=-1                                  \


### PR DESCRIPTION
Allow arbitrary options to be passed to Jenkins through the new JENKINS_OPTS environment variable. This behaves the same as JVM_OPTS.