### PR TITLE
Move ${JENKINS_OPTS} so that it goes before -jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ java ${JVM_OPTS}                                    \
     -Djava.awt.headless=true                        \
     -Dhudson.DNSMultiCast.disabled=true             \
     -Djenkins.install.runSetupWizard=false          \
-    -jar ${JENKINS_FOLDER}/jenkins.war              \
     ${JENKINS_OPTS}                                 \
+    -jar ${JENKINS_FOLDER}/jenkins.war              \
     --httpPort=${PORT1}                             \
     --webroot=${JENKINS_FOLDER}/war                 \
     --ajp13Port=-1                                  \


### PR DESCRIPTION
Otherwise, an attempt to pass multile "-D" options raises an error:

```
I1007 20:23:13.065661 26957 docker.cpp:815] Running docker -H unix:///var/run/docker.sock run --cpu-shares 1024 --memory 2147483648 -e MARATHON_APP_LABEL_DCOS_PACKAGE_SOURCE=https://universe.mesosphere.com/repo -e LD_LIBRARY_PATH=/opt/mesosphere/lib -e MARATHON_APP_VERSION=2016-10-07T20:11:15.396Z -e HOST=10.5.1.41 -e MARATHON_APP_LABEL_MARATHON_SINGLE_INSTANCE_APP=true -e MARATHON_APP_RESOURCE_CPUS=1.0 -e MARATHON_APP_LABEL_DCOS_PACKAGE_REGISTRY_VERSION=2.0 -e SSH_KNOWN_HOSTS=github.com -e MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME=http -e PORT_10102=5502 -e JENKINS_CONTEXT=/service/jenkins -e MARATHON_APP_RESOURCE_GPUS=0 -e MARATHON_APP_LABEL_DCOS_PACKAGE_RELEASE=13 -e JENKINS_AGENT_ROLE=* -e JVM_OPTS=-Xms1024m -Xmx1024m -e MARATHON_APP_LABEL_DCOS_SERVICE_NAME=jenkins -e PORT_10103=5503 -e MARATHON_APP_DOCKER_IMAGE=mesosphere/jenkins:2.0.1-2.7.4 -e MARATHON_APP_LABEL_DCOS_PACKAGE_NAME=jenkins -e MARATHON_APP_LABEL_DCOS_PACKAGE_VERSION=2.0.1-2.7.4 -e JENKINS_MESOS_MASTER=zk://leader.mesos:2181/mesos -e MESOS_TASK_ID=jenkins.ded5c56c-8ccb-11e6-ae7c-ea67d46665b6 -e PORT=5502 -e JENKINS_AGENT_USER=root -e MARATHON_APP_LABEL_DCOS_SERVICE_PORT_INDEX=0 -e MARATHON_APP_RESOURCE_MEM=2048.0 -e PORTS=5502,5503 -e PORT1=5503 -e JENKINS_OPTS="-Duser.timezone=America/Los_Angeles -Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Los_Angeles" -e MARATHON_APP_LABEL_DCOS_PACKAGE_IS_FRAMEWORK=true -e MARATHON_APP_RESOURCE_DISK=0.0 -e MARATHON_APP_LABELS=DCOS_PACKAGE_RELEASE DCOS_SERVICE_SCHEME DCOS_PACKAGE_SOURCE DCOS_PACKAGE_REGISTRY_VERSION DCOS_SERVICE_NAME DCOS_PACKAGE_FRAMEWORK_NAME DCOS_SERVICE_PORT_INDEX DCOS_PACKAGE_VERSION DCOS_PACKAGE_NAME MARATHON_SINGLE_INSTANCE_APP DCOS_PACKAGE_IS_FRAMEWORK -e MARATHON_APP_LABEL_DCOS_PACKAGE_FRAMEWORK_NAME=jenkins -e JENKINS_FRAMEWORK_NAME=jenkins -e MARATHON_APP_ID=/jenkins -e PORT0=5502 -e LIBPROCESS_IP=10.5.1.41 -e MESOS_SANDBOX=/mnt/mesos/sandbox -e MESOS_CONTAINER_NAME=mesos-84c9902f-01c5-4419-ae9a-8d3c69859a3e-S8.09924f88-d15e-40e7-80f5-b17175cc2362 -v /mnt/efs/jenkins:/var/jenkins_home:rw -v /opt/mesosphere:/opt/mesosphere:ro -v /var/lib/mesos/slave/slaves/84c9902f-01c5-4419-ae9a-8d3c69859a3e-S8/frameworks/84c9902f-01c5-4419-ae9a-8d3c69859a3e-0000/executors/jenkins.ded5c56c-8ccb-11e6-ae7c-ea67d46665b6/runs/09924f88-d15e-40e7-80f5-b17175cc2362:/mnt/mesos/sandbox --net host --name mesos-84c9902f-01c5-4419-ae9a-8d3c69859a3e-S8.09924f88-d15e-40e7-80f5-b17175cc2362 mesosphere/jenkins:2.0.1-2.7.4
nginx: /opt/mesosphere/lib/libcrypto.so.1.0.0: no version information available (required by nginx)
nginx: /opt/mesosphere/lib/libssl.so.1.0.0: no version information available (required by nginx)
nginx: /opt/mesosphere/lib/libssl.so.1.0.0: no version information available (required by nginx)
Exception in thread "main" java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at Main._main(Main.java:246)
    at Main.main(Main.java:91)
Caused by: java.lang.IllegalArgumentException: Multiple command line argument specified: -Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Los_Angeles"
    at winstone.cmdline.CmdLineParser.parse(CmdLineParser.java:68)
    at winstone.Launcher.getArgsFromCommandLine(Launcher.java:359)
    at winstone.Launcher.main(Launcher.java:332)
    ... 6 more
```
