### PR TITLE
Upgrade to 2.19.3 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ up and running quickly with Jenkins on DC/OS.
 
 ## Included in this repo
 Base packages:
-  * [Jenkins][jenkins-home] 2.19.1 (LTS)
+  * [Jenkins][jenkins-home] 2.19.3 (LTS)
   * [Nginx][nginx-home] 1.10.1
 
 Jenkins plugins:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>jenkins-war</artifactId>
-			<version>2.19.1</version>
+			<version>2.19.3</version>
 			<type>war</type>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Upgrade Jenkins to LTS 2.19.3 due to security issue.

More information available from:
  * https://jenkins.io/blog/2016/11/16/security-updates-addressing-zero-day/
  * https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-11-16
  * https://groups.google.com/forum/#!msg/jenkinsci-advisories/-fc-w9tNEJE/GRvEzWoJBgAJ